### PR TITLE
Fix kubectl command not found warning

### DIFF
--- a/dot_zshrc
+++ b/dot_zshrc
@@ -57,7 +57,7 @@ antigen bundle greymd/docker-zsh-completion
 antigen bundle MichaelAquilina/zsh-you-should-use
 # antigen bundle changyuheng/fz
 antigen bundle zsh-users/zsh-completions
-antigen bundle dbz/kube-aliases
+command -v kubectl &>/dev/null && antigen bundle dbz/kube-aliases
 antigen apply
 
 [[ -f "$HOME/aliases.sh" ]] && source $HOME/aliases.sh


### PR DESCRIPTION
Only load the dbz/kube-aliases antigen plugin when kubectl is available in PATH to prevent "command not found: kubectl" warning.