### PR TITLE
Enable tmux passthrough for all panes

### DIFF
--- a/dot_tmux.conf
+++ b/dot_tmux.conf
@@ -28,8 +28,8 @@ set -g repeat-time 300
 # Focus events for vim/neovim
 set -g focus-events on
 
-# Allow passthrough of escape sequences (needed for notifications over SSH)
-set -g allow-passthrough on
+# Allow passthrough of escape sequences (needed for images, OSC 52 clipboard, notifications over SSH)
+set -g allow-passthrough all
 
 # Don't exit tmux when closing a session
 set -g detach-on-destroy off


### PR DESCRIPTION
## Summary
- Changed `allow-passthrough` from `on` (active pane only) to `all` so escape sequences pass through in all panes, not just the focused one
- This enables proper support for image protocols (Kitty, Sixel), OSC 52 clipboard, and notifications over SSH in background panes

## Test plan
- [ ] Verify tmux starts without errors after reloading config
- [ ] Confirm escape sequences (e.g., OSC 52 clipboard) work in non-focused panes

https://claude.ai/code/session_01LRAbitVE59RTMV2zhkPKfg