### PR TITLE
Use history-substring-search for up arrow, scope atuin to sessions

### DIFF
--- a/dot_config/atuin/config.toml
+++ b/dot_config/atuin/config.toml
@@ -1,0 +1,8 @@
+# ABOUTME: Atuin shell history configuration.
+# ABOUTME: Uses session-scoped history for up-arrow; Ctrl+R searches all history.
+
+## Use session-specific history when pressing up arrow, not global history
+filter_mode_shell_up_arrow = "session"
+
+## Default filter mode for the full search UI (Ctrl+R)
+filter_mode = "global"

--- a/dot_zsh_plugins.txt
+++ b/dot_zsh_plugins.txt
@@ -4,4 +4,5 @@ greymd/docker-zsh-completion
 MichaelAquilina/zsh-you-should-use
 zsh-users/zsh-completions
 zsh-users/zsh-autosuggestions
+zsh-users/zsh-history-substring-search
 zdharma-continuum/fast-syntax-highlighting

--- a/dot_zshrc
+++ b/dot_zshrc
@@ -46,8 +46,8 @@ export FZF_ALT_C_COMMAND='fd --type d --hidden --follow --exclude .git'
 export FZF_ALT_C_OPTS="--preview 'eza --tree --level=2 --color=always {}'"
 source <(fzf --zsh)
 
-# Atuin shell history (binds Up arrow and Ctrl+R)
-eval "$(atuin init zsh)"
+# Atuin shell history (Ctrl+R only; up arrow handled by history-substring-search)
+eval "$(atuin init zsh --disable-up-arrow)"
 
 # Install starship
 command -v starship &>/dev/null || sh -c "$(curl -fsSL https://starship.rs/install.sh)"
@@ -71,6 +71,12 @@ source <(carapace _carapace)
 source "$(brew --prefix antidote)/share/antidote/antidote.zsh"
 antidote load
 command -v kubectl &>/dev/null && source <(antidote bundle dbz/kube-aliases)
+
+# Bind up/down arrows to history-substring-search
+bindkey '^[[A' history-substring-search-up
+bindkey '^[[B' history-substring-search-down
+bindkey '^[OA' history-substring-search-up
+bindkey '^[OB' history-substring-search-down
 
 [[ -f "$HOME/aliases.sh" ]] && source $HOME/aliases.sh
 [[ -f "$HOME/functions.sh" ]] && source $HOME/functions.sh


### PR DESCRIPTION
## Summary
- Add `zsh-history-substring-search` plugin via antidote and bind up/down arrows to it (both CSI `^[[A/B` and SS3 `^[OA/B` sequences)
- Disable atuin's up-arrow binding (`--disable-up-arrow`), keeping Ctrl+R for full interactive search
- Add `dot_config/atuin/config.toml` with `filter_mode_shell_up_arrow = "session"` so atuin uses session-specific history instead of global

## Test plan
- [ ] Open a new shell and verify up arrow performs substring search on current input
- [ ] Verify Ctrl+R opens atuin's full search UI
- [ ] Verify atuin's session filter works (history from other sessions shouldn't appear when using up arrow via atuin)

https://claude.ai/code/session_013gVhuqpT5mWanvAKUso22A